### PR TITLE
Add Laravel + React skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+APP_NAME="Fort Lauderdale Missile-Shelter Finder"
+APP_ENV=local
+APP_KEY=
+APP_DEBUG=true
+APP_URL=http://localhost
+
+LOG_CHANNEL=stack
+
+DB_CONNECTION=mysql
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_DATABASE=shelters
+DB_USERNAME=root
+DB_PASSWORD=
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# aint_this_a_bitch
+# Fort Lauderdale Missile-Shelter Finder
+
+This is a minimal skeleton of a Laravel 10 + React 18 single-page application for locating missile shelters.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and set database credentials.
+2. Run migrations and seeders:
+   ```bash
+   php artisan migrate --seed
+   ```
+3. Build front-end assets:
+   ```bash
+   npm run build
+   ```
+
+## Development
+
+Use `npm run dev` to run Vite in development mode.

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -1,0 +1,18 @@
+<?php
+namespace App\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+
+class Kernel extends ConsoleKernel
+{
+    protected function schedule(Schedule $schedule): void
+    {
+        //
+    }
+
+    protected function commands(): void
+    {
+        $this->load(__DIR__.'/Commands');
+    }
+}

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -1,0 +1,19 @@
+<?php
+namespace App\Exceptions;
+
+use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Throwable;
+
+class Handler extends ExceptionHandler
+{
+    protected $levels = [];
+
+    protected $dontReport = [];
+
+    protected $dontFlash = ['password', 'password_confirmation'];
+
+    public function register(): void
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/ShelterController.php
+++ b/app/Http/Controllers/ShelterController.php
@@ -1,0 +1,24 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Shelter;
+use Illuminate\Http\Request;
+
+class ShelterController extends Controller
+{
+    public function index(Request $request)
+    {
+        $search = $request->query('search');
+        $query = Shelter::query();
+        if ($search) {
+            $query->where(function ($q) use ($search) {
+                $q->where('city', 'like', "%{$search}%")
+                    ->orWhere('county', 'like', "%{$search}%")
+                    ->orWhere('name', 'like', "%{$search}%")
+                    ->orWhere('phone', 'like', "%{$search}%");
+            });
+        }
+        $shelters = $query->get();
+        return response()->json($shelters);
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -1,0 +1,18 @@
+<?php
+namespace App\Http;
+
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
+class Kernel extends HttpKernel
+{
+    protected $middlewareGroups = [
+        'web' => [
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
+
+        'api' => [
+            'throttle:api',
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
+    ];
+}

--- a/app/Models/Shelter.php
+++ b/app/Models/Shelter.php
@@ -1,0 +1,16 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Shelter extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name', 'type', 'description', 'address',
+        'city', 'county', 'phone', 'latitude', 'longitude',
+        'requirements'
+    ];
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,0 +1,21 @@
+<?php
+$app = new Illuminate\Foundation\Application(
+    dirname(__DIR__)
+);
+
+$app->singleton(
+    Illuminate\Contracts\Http\Kernel::class,
+    App\Http\Kernel::class
+);
+
+$app->singleton(
+    Illuminate\Contracts\Console\Kernel::class,
+    App\Console\Kernel::class
+);
+
+$app->singleton(
+    Illuminate\Contracts\Debug\ExceptionHandler::class,
+    App\Exceptions\Handler::class
+);
+
+return $app;

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "sean/fort-lauderdale-shelter-finder",
+    "type": "project",
+    "require": {
+        "php": "^8.1",
+        "laravel/framework": "^10.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    },
+    "scripts": {
+        "post-root-package-install": [
+            "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
+        ]
+    }
+}

--- a/database/migrations/2024_01_01_000000_create_shelters_table.php
+++ b/database/migrations/2024_01_01_000000_create_shelters_table.php
@@ -1,0 +1,27 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void {
+        Schema::create('shelters', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->enum('type', ['public','private','community']);
+            $table->text('description')->nullable();
+            $table->string('address');
+            $table->string('city');
+            $table->string('county');
+            $table->string('phone', 32)->nullable();
+            $table->decimal('latitude', 9, 6);
+            $table->decimal('longitude', 9, 6);
+            $table->text('requirements')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void {
+        Schema::dropIfExists('shelters');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -1,0 +1,15 @@
+<?php
+namespace Database\Seeders;
+
+use Database\Seeders\ShelterSeeder;
+use Illuminate\Database\Seeder;
+
+class DatabaseSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $this->call([
+            ShelterSeeder::class,
+        ]);
+    }
+}

--- a/database/seeders/ShelterSeeder.php
+++ b/database/seeders/ShelterSeeder.php
@@ -1,0 +1,24 @@
+<?php
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Shelter;
+
+class ShelterSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Shelter::create([
+            'name' => 'Central Park Shelter',
+            'type' => 'public',
+            'description' => 'Main municipal shelter.',
+            'address' => '123 Main St',
+            'city' => 'Fort Lauderdale',
+            'county' => 'Broward',
+            'phone' => '555-1234',
+            'latitude' => 26.1224,
+            'longitude' => -80.1373,
+            'requirements' => 'ID required',
+        ]);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "laravel-vite-plugin": "^0.8.0",
+    "vite": "^4.0.0"
+  },
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-router-dom": "^6.0.0",
+    "react-leaflet": "^4.0.0",
+    "leaflet": "^1.9.0",
+    "tailwindcss": "^3.0.0",
+    "@heroicons/react": "^2.0.0",
+    "simple-icons": "^10.0.0"
+  }
+}

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,6 @@
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule ^ index.php [L]
+</IfModule>

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,10 @@
+<?php
+define('LARAVEL_START', microtime(true));
+require __DIR__.'/../vendor/autoload.php';
+$app = require_once __DIR__.'/../bootstrap/app.php';
+$kernel = $app->make(Illuminate\Contracts\Http\Kernel::class);
+$response = $kernel->handle(
+    $request = Illuminate\Http\Request::capture()
+);
+$response->send();
+$kernel->terminate($request, $response);

--- a/resources/js/App.jsx
+++ b/resources/js/App.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import MapPage from './components/MapPage';
+
+export default function App() {
+    return (
+        <Router>
+            <Routes>
+                <Route path="/*" element={<MapPage />} />
+            </Routes>
+        </Router>
+    );
+}

--- a/resources/js/components/FooterPopup.jsx
+++ b/resources/js/components/FooterPopup.jsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+
+export default function FooterPopup() {
+    const [open, setOpen] = useState(false);
+    const year = new Date().getFullYear();
+
+    return (
+        <div className="fixed bottom-0 left-1/2 transform -translate-x-1/2 text-center">
+            <button
+                className="rounded-full bg-white shadow p-2"
+                onClick={() => setOpen(!open)}
+            >
+                ^
+            </button>
+            <div
+                className={`transition-transform duration-300 ease-in-out bg-white shadow mt-2 p-4 rounded ${open ? 'translate-y-0' : 'translate-y-full'}`}
+                style={{ height: '12rem' }}
+            >
+                <p>Designed & built with ❤️ + 🤖 by <a href="https://seanblake.info" target="_blank">Sean</a></p>
+                <p>© {year}</p>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/components/Hamburger.jsx
+++ b/resources/js/components/Hamburger.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function Hamburger({ onClick, open }) {
+    return (
+        <button
+            className="fixed top-4 left-4 z-50 w-15 h-15 rounded-full bg-white shadow"
+            onClick={onClick}
+        >
+            <span className={open ? 'transform rotate-45' : ''}>☰</span>
+        </button>
+    );
+}

--- a/resources/js/components/MapPage.jsx
+++ b/resources/js/components/MapPage.jsx
@@ -1,0 +1,36 @@
+import React, { useState, useEffect } from 'react';
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import Hamburger from './Hamburger';
+import SideDrawer from './SideDrawer';
+import FooterPopup from './FooterPopup';
+
+export default function MapPage() {
+    const [shelters, setShelters] = useState([]);
+    const [open, setOpen] = useState(false);
+
+    useEffect(() => {
+        fetch('/api/shelters')
+            .then(res => res.json())
+            .then(data => setShelters(data));
+    }, []);
+
+    return (
+        <div className="h-screen w-screen relative">
+            <Hamburger onClick={() => setOpen(!open)} open={open} />
+            <SideDrawer open={open}>Menu</SideDrawer>
+            <MapContainer center={[26.1224, -80.1373]} zoom={12} className="h-full w-full">
+                <TileLayer
+                    attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'
+                    url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                />
+                {shelters.map(s => (
+                    <Marker key={s.id} position={[s.latitude, s.longitude]}>
+                        <Popup>{s.name}</Popup>
+                    </Marker>
+                ))}
+            </MapContainer>
+            <FooterPopup />
+        </div>
+    );
+}

--- a/resources/js/components/SideDrawer.jsx
+++ b/resources/js/components/SideDrawer.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function SideDrawer({ open, children }) {
+    return (
+        <div
+            className={`fixed top-0 left-0 h-full w-72 bg-white shadow transform transition-transform ease-in-out duration-300 ${open ? 'translate-x-0' : '-translate-x-full'}`}
+            style={{ zIndex: 1000 }}
+        >
+            {children}
+        </div>
+    );
+}

--- a/resources/js/main.jsx
+++ b/resources/js/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './style.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+    <React.StrictMode>
+        <App />
+    </React.StrictMode>
+);

--- a/resources/js/style.css
+++ b/resources/js/style.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Fort Lauderdale Shelter Finder</title>
+    @viteReactRefresh
+    @vite('resources/js/main.jsx')
+</head>
+<body class="antialiased">
+<div id="root"></div>
+</body>
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,5 @@
+<?php
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\ShelterController;
+
+Route::get('/shelters', [ShelterController::class, 'index'])->middleware('throttle:60,1');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,4 @@
+<?php
+use Illuminate\Support\Facades\Route;
+
+Route::view('/{any}', 'app')->where('any', '.*');

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './resources/js/**/*.{js,jsx,ts,tsx}',
+    './resources/views/**/*.blade.php',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import laravel from 'laravel-vite-plugin';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+    plugins: [
+        laravel({
+            input: 'resources/js/main.jsx',
+            refresh: true,
+        }),
+        react(),
+    ],
+});


### PR DESCRIPTION
## Summary
- scaffold Laravel-like structure with composer.json, migrations, model, controller, routes
- add React SPA files powered by Vite and Tailwind
- provide seeders, basic map component, and placeholder UI elements
- update README with setup instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685b2e672cbc8326904a41235ed803d5